### PR TITLE
DataStore での NullReferenceException を抑制

### DIFF
--- a/Assets/Scripts/CAFU/Core/Presentation/ViewController.cs
+++ b/Assets/Scripts/CAFU/Core/Presentation/ViewController.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+// ReSharper disable VirtualMemberNeverOverridden.Global
 
 namespace CAFU.Core.Presentation {
 
@@ -24,7 +25,7 @@ namespace CAFU.Core.Presentation {
 
         public TPresenter Presenter { get; protected set; }
 
-        protected virtual void Awake() {
+        protected virtual void Start() {
             IViewControllerBuilder builder = this as IViewControllerBuilder;
             if (builder != default(IViewControllerBuilder)) {
                 builder.Build();
@@ -39,12 +40,11 @@ namespace CAFU.Core.Presentation {
 
         public static TViewController Instance { get; private set; }
 
-        protected override void Awake() {
+        protected virtual void Awake() {
             Instance = (TViewController)this;
-            base.Awake();
         }
 
-        private void OnDestroy() {
+        protected virtual void OnDestroy() {
             Instance = null;
         }
 


### PR DESCRIPTION
* Awake で Build を呼んでしまうと、Singleton な DataStore とかの準備が整う前に呼び出しを行ってしまう可能性があるため、Start で Build をコールするように変更