### PR TITLE
シーン読み込み時の NullReferenceException を修正

### DIFF
--- a/Assets/Scripts/CAFU/Core/Presentation/ViewController.cs
+++ b/Assets/Scripts/CAFU/Core/Presentation/ViewController.cs
@@ -7,7 +7,7 @@ namespace CAFU.Core.Presentation {
 
     }
 
-    public interface IViewControllerPresenter<out TPresenter> {
+    public interface IViewControllerPresenter<out TPresenter> : IViewController {
 
         TPresenter Presenter { get; }
 


### PR DESCRIPTION
* 実装としては cafu_routing 側だが、バグの原因は IViewController の継承関係によるモノでした