### PR TITLE
Translator の引数制約を緩める

### DIFF
--- a/Assets/Scripts/CAFU/Core/Domain/Translator/Translator.cs
+++ b/Assets/Scripts/CAFU/Core/Domain/Translator/Translator.cs
@@ -35,7 +35,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IModelTranslator<in TEntity1, out TModel> : IModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         TModel Translate(TEntity1 entity);
@@ -43,7 +42,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IModelTranslator<in TEntity1, in TEntity2, out TModel> : IModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         TModel Translate(TEntity1 entity1, TEntity2 entity2);
@@ -51,7 +49,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IModelTranslator<in TEntity1, in TEntity2, in TEntity3, out TModel> : IModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         TModel Translate(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3);
@@ -59,7 +56,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, out TModel> : IModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         TModel Translate(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4);
@@ -67,7 +63,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, out TModel> : IModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         TModel Translate(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5);
@@ -75,7 +70,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, out TModel> : IModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         TModel Translate(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6);
@@ -83,7 +77,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, out TModel> : IModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         TModel Translate(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7);
@@ -91,7 +84,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, out TModel> : IModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         TModel Translate(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7, TEntity8 entity8);
@@ -99,7 +91,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, in TEntity9, out TModel> : IModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         TModel Translate(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7, TEntity8 entity8, TEntity9 entity9);
@@ -107,7 +98,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, in TEntity9, in TEntity10, out TModel> : IModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         TModel Translate(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7, TEntity8 entity8, TEntity9 entity9, TEntity10 entity10);
@@ -115,7 +105,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IEntityTranslator<in TModel1, out TEntity> : IEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         TEntity Translate(TModel1 model);
@@ -123,7 +112,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IEntityTranslator<in TModel1, in TModel2, out TEntity> : IEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         TEntity Translate(TModel1 model1, TModel2 model2);
@@ -131,7 +119,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IEntityTranslator<in TModel1, in TModel2, in TModel3, out TEntity> : IEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         TEntity Translate(TModel1 model1, TModel2 model2, TModel3 model3);
@@ -139,7 +126,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, out TEntity> : IEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         TEntity Translate(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4);
@@ -147,7 +133,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, out TEntity> : IEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         TEntity Translate(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5);
@@ -155,7 +140,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, out TEntity> : IEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         TEntity Translate(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6);
@@ -163,7 +147,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, out TEntity> : IEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         TEntity Translate(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7);
@@ -171,7 +154,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, out TEntity> : IEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         TEntity Translate(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7, TModel8 model8);
@@ -179,7 +161,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, in TModel9, out TEntity> : IEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         TEntity Translate(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7, TModel8 model8, TModel9 model9);
@@ -187,7 +168,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, in TModel9, in TModel10, out TEntity> : IEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         TEntity Translate(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7, TModel8 model8, TModel9 model9, TModel10 model10);
@@ -195,7 +175,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncModelTranslator<in TEntity1, TModel> : IAsyncModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         IObservable<TModel> TranslateAsObservable(TEntity1 entity);
@@ -203,7 +182,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncModelTranslator<in TEntity1, in TEntity2, TModel> : IAsyncModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2);
@@ -211,7 +189,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, TModel> : IAsyncModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3);
@@ -219,7 +196,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, TModel> : IAsyncModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4);
@@ -227,7 +203,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, TModel> : IAsyncModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5);
@@ -235,7 +210,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, TModel> : IAsyncModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6);
@@ -243,7 +217,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, TModel> : IAsyncModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7);
@@ -251,7 +224,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, TModel> : IAsyncModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7, TEntity8 entity8);
@@ -259,7 +231,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, in TEntity9, TModel> : IAsyncModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7, TEntity8 entity8, TEntity9 entity9);
@@ -267,7 +238,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, in TEntity9, in TEntity10, TModel> : IAsyncModelTranslator
-        where TEntity1 : IEntity
         where TModel : Model.IModel {
 
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7, TEntity8 entity8, TEntity9 entity9, TEntity10 entity10);
@@ -275,7 +245,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncEntityTranslator<in TModel1, TEntity> : IAsyncEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         IObservable<TEntity> TranslateAsObservable(TModel1 model);
@@ -283,7 +252,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncEntityTranslator<in TModel1, in TModel2, TEntity> : IAsyncEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2);
@@ -291,7 +259,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, TEntity> : IAsyncEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3);
@@ -299,7 +266,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, TEntity> : IAsyncEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4);
@@ -307,7 +273,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, TEntity> : IAsyncEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5);
@@ -315,7 +280,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, TEntity> : IAsyncEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6);
@@ -323,7 +287,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, TEntity> : IAsyncEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7);
@@ -331,7 +294,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, TEntity> : IAsyncEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7, TModel8 model8);
@@ -339,7 +301,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, in TModel9, TEntity> : IAsyncEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7, TModel8 model8, TModel9 model9);
@@ -347,7 +308,6 @@ namespace CAFU.Core.Domain.Translator {
     }
 
     public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, in TModel9, in TModel10, TEntity> : IAsyncEntityTranslator
-        where TModel1 : Model.IModel
         where TEntity : IEntity {
 
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7, TModel8 model8, TModel9 model9, TModel10 model10);


### PR DESCRIPTION
* Translate の引数は IEntity や IModel でなくても OK とする
  * シンプルに enum を渡したいケースが少なくないため、許容します