### PR TITLE
Add DataStoreResolver

### DIFF
--- a/Assets/Scripts/Data/DataStore/DataStore.cs
+++ b/Assets/Scripts/Data/DataStore/DataStore.cs
@@ -42,6 +42,12 @@ namespace CAFU.Core.Data.DataStore
     }
 
     [PublicAPI]
+    public interface IDataStoreResolver<out TDataStore> where TDataStore : IDataStore
+    {
+        TDataStore Resolve();
+    }
+
+    [PublicAPI]
     public class DefaultDataStoreFactory<TDataStore> : DefaultFactory<TDataStore>, IDataStoreFactory<TDataStore>
         where TDataStore : IDataStore, new()
     {
@@ -51,6 +57,15 @@ namespace CAFU.Core.Data.DataStore
     public class SceneDataStoreFactory<TDataStore> : SceneFactory<TDataStore>, IDataStoreFactory<TDataStore>
         where TDataStore : Object, IDataStore
     {
+    }
+
+    [PublicAPI]
+    public class DefaultDataStoreResolver<TDataStore> : IDataStoreResolver<TDataStore> where TDataStore : IDataStore, new()
+    {
+        public TDataStore Resolve()
+        {
+            return new DefaultDataStoreFactory<TDataStore>().Create();
+        }
     }
 
     [PublicAPI]


### PR DESCRIPTION
## What

* `IDataStoreResolver` なるインタフェースと `DefaultDataStoreResolver` なる基本クラスを提供

## Why

* Repository で利用する DataStore を決定するロジックを切り出したかった
    * Repository.Factory で決定してしまうとランタイムで動的に切り替えるコトが難しいため、1段抽象レイヤーを噛ます