### PR TITLE
Change interface names

### DIFF
--- a/Assets/Scripts/Domain/Translator/Translator.cs
+++ b/Assets/Scripts/Domain/Translator/Translator.cs
@@ -1,4 +1,5 @@
-﻿using CAFU.Core.Data.Entity;
+﻿using System.Threading.Tasks;
+using CAFU.Core.Data.Entity;
 using CAFU.Core.Utility;
 using JetBrains.Annotations;
 using UniRx;
@@ -16,6 +17,11 @@ namespace CAFU.Core.Domain.Translator
     }
 
     [PublicAPI]
+    public interface IObservableTranslator
+    {
+    }
+
+    [PublicAPI]
     public interface IAsyncTranslator
     {
     }
@@ -27,6 +33,16 @@ namespace CAFU.Core.Domain.Translator
 
     [PublicAPI]
     public interface IEntityTranslator : ITranslator
+    {
+    }
+
+    [PublicAPI]
+    public interface IObservableModelTranslator : IObservableTranslator, IModelTranslator
+    {
+    }
+
+    [PublicAPI]
+    public interface IObservableEntityTranslator : IObservableTranslator, IEntityTranslator
     {
     }
 
@@ -181,143 +197,283 @@ namespace CAFU.Core.Domain.Translator
     }
 
     [PublicAPI]
-    public interface IAsyncModelTranslator<in TEntity1, TModel> : IAsyncModelTranslator
+    public interface IObservableModelTranslator<in TEntity1, TModel> : IObservableModelTranslator
         where TModel : Model.IModel
     {
         IObservable<TModel> TranslateAsObservable(TEntity1 entity);
     }
 
     [PublicAPI]
-    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, TModel> : IAsyncModelTranslator
+    public interface IObservableModelTranslator<in TEntity1, in TEntity2, TModel> : IObservableModelTranslator
         where TModel : Model.IModel
     {
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2);
     }
 
     [PublicAPI]
-    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, TModel> : IAsyncModelTranslator
+    public interface IObservableModelTranslator<in TEntity1, in TEntity2, in TEntity3, TModel> : IObservableModelTranslator
         where TModel : Model.IModel
     {
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3);
     }
 
     [PublicAPI]
-    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, TModel> : IAsyncModelTranslator
+    public interface IObservableModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, TModel> : IObservableModelTranslator
         where TModel : Model.IModel
     {
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4);
     }
 
     [PublicAPI]
-    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, TModel> : IAsyncModelTranslator
+    public interface IObservableModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, TModel> : IObservableModelTranslator
         where TModel : Model.IModel
     {
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5);
     }
 
     [PublicAPI]
-    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, TModel> : IAsyncModelTranslator
+    public interface IObservableModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, TModel> : IObservableModelTranslator
         where TModel : Model.IModel
     {
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6);
     }
 
     [PublicAPI]
-    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, TModel> : IAsyncModelTranslator
+    public interface IObservableModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, TModel> : IObservableModelTranslator
         where TModel : Model.IModel
     {
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7);
     }
 
     [PublicAPI]
-    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, TModel> : IAsyncModelTranslator
+    public interface IObservableModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, TModel> : IObservableModelTranslator
         where TModel : Model.IModel
     {
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7, TEntity8 entity8);
     }
 
     [PublicAPI]
-    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, in TEntity9, TModel> : IAsyncModelTranslator
+    public interface IObservableModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, in TEntity9, TModel> : IObservableModelTranslator
         where TModel : Model.IModel
     {
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7, TEntity8 entity8, TEntity9 entity9);
     }
 
     [PublicAPI]
-    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, in TEntity9, in TEntity10, TModel> : IAsyncModelTranslator
+    public interface IObservableModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, in TEntity9, in TEntity10, TModel> : IObservableModelTranslator
         where TModel : Model.IModel
     {
         IObservable<TModel> TranslateAsObservable(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7, TEntity8 entity8, TEntity9 entity9, TEntity10 entity10);
     }
 
     [PublicAPI]
-    public interface IAsyncEntityTranslator<in TModel1, TEntity> : IAsyncEntityTranslator
+    public interface IObservableEntityTranslator<in TModel1, TEntity> : IObservableEntityTranslator
         where TEntity : IEntity
     {
         IObservable<TEntity> TranslateAsObservable(TModel1 model);
     }
 
     [PublicAPI]
-    public interface IAsyncEntityTranslator<in TModel1, in TModel2, TEntity> : IAsyncEntityTranslator
+    public interface IObservableEntityTranslator<in TModel1, in TModel2, TEntity> : IObservableEntityTranslator
         where TEntity : IEntity
     {
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2);
     }
 
     [PublicAPI]
-    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, TEntity> : IAsyncEntityTranslator
+    public interface IObservableEntityTranslator<in TModel1, in TModel2, in TModel3, TEntity> : IObservableEntityTranslator
         where TEntity : IEntity
     {
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3);
     }
 
     [PublicAPI]
-    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, TEntity> : IAsyncEntityTranslator
+    public interface IObservableEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, TEntity> : IObservableEntityTranslator
         where TEntity : IEntity
     {
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4);
     }
 
     [PublicAPI]
-    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, TEntity> : IAsyncEntityTranslator
+    public interface IObservableEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, TEntity> : IObservableEntityTranslator
         where TEntity : IEntity
     {
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5);
     }
 
     [PublicAPI]
-    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, TEntity> : IAsyncEntityTranslator
+    public interface IObservableEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, TEntity> : IObservableEntityTranslator
         where TEntity : IEntity
     {
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6);
     }
 
     [PublicAPI]
-    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, TEntity> : IAsyncEntityTranslator
+    public interface IObservableEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, TEntity> : IObservableEntityTranslator
         where TEntity : IEntity
     {
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7);
     }
 
     [PublicAPI]
-    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, TEntity> : IAsyncEntityTranslator
+    public interface IObservableEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, TEntity> : IObservableEntityTranslator
         where TEntity : IEntity
     {
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7, TModel8 model8);
     }
 
     [PublicAPI]
-    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, in TModel9, TEntity> : IAsyncEntityTranslator
+    public interface IObservableEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, in TModel9, TEntity> : IObservableEntityTranslator
         where TEntity : IEntity
     {
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7, TModel8 model8, TModel9 model9);
     }
 
     [PublicAPI]
-    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, in TModel9, in TModel10, TEntity> : IAsyncEntityTranslator
+    public interface IObservableEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, in TModel9, in TModel10, TEntity> : IObservableEntityTranslator
         where TEntity : IEntity
     {
         IObservable<TEntity> TranslateAsObservable(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7, TModel8 model8, TModel9 model9, TModel10 model10);
+    }
+
+    [PublicAPI]
+    public interface IAsyncModelTranslator<in TEntity1, TModel> : IAsyncModelTranslator
+        where TModel : Model.IModel
+    {
+        Task<TModel> TranslateAsync(TEntity1 entity);
+    }
+
+    [PublicAPI]
+    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, TModel> : IAsyncModelTranslator
+        where TModel : Model.IModel
+    {
+        Task<TModel> TranslateAsync(TEntity1 entity1, TEntity2 entity2);
+    }
+
+    [PublicAPI]
+    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, TModel> : IAsyncModelTranslator
+        where TModel : Model.IModel
+    {
+        Task<TModel> TranslateAsync(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3);
+    }
+
+    [PublicAPI]
+    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, TModel> : IAsyncModelTranslator
+        where TModel : Model.IModel
+    {
+        Task<TModel> TranslateAsync(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4);
+    }
+
+    [PublicAPI]
+    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, TModel> : IAsyncModelTranslator
+        where TModel : Model.IModel
+    {
+        Task<TModel> TranslateAsync(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5);
+    }
+
+    [PublicAPI]
+    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, TModel> : IAsyncModelTranslator
+        where TModel : Model.IModel
+    {
+        Task<TModel> TranslateAsync(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6);
+    }
+
+    [PublicAPI]
+    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, TModel> : IAsyncModelTranslator
+        where TModel : Model.IModel
+    {
+        Task<TModel> TranslateAsync(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7);
+    }
+
+    [PublicAPI]
+    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, TModel> : IAsyncModelTranslator
+        where TModel : Model.IModel
+    {
+        Task<TModel> TranslateAsync(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7, TEntity8 entity8);
+    }
+
+    [PublicAPI]
+    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, in TEntity9, TModel> : IAsyncModelTranslator
+        where TModel : Model.IModel
+    {
+        Task<TModel> TranslateAsync(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7, TEntity8 entity8, TEntity9 entity9);
+    }
+
+    [PublicAPI]
+    public interface IAsyncModelTranslator<in TEntity1, in TEntity2, in TEntity3, in TEntity4, in TEntity5, in TEntity6, in TEntity7, in TEntity8, in TEntity9, in TEntity10, TModel> : IAsyncModelTranslator
+        where TModel : Model.IModel
+    {
+        Task<TModel> TranslateAsync(TEntity1 entity1, TEntity2 entity2, TEntity3 entity3, TEntity4 entity4, TEntity5 entity5, TEntity6 entity6, TEntity7 entity7, TEntity8 entity8, TEntity9 entity9, TEntity10 entity10);
+    }
+
+    [PublicAPI]
+    public interface IAsyncEntityTranslator<in TModel1, TEntity> : IAsyncEntityTranslator
+        where TEntity : IEntity
+    {
+        Task<TEntity> TranslateAsync(TModel1 model);
+    }
+
+    [PublicAPI]
+    public interface IAsyncEntityTranslator<in TModel1, in TModel2, TEntity> : IAsyncEntityTranslator
+        where TEntity : IEntity
+    {
+        Task<TEntity> TranslateAsync(TModel1 model1, TModel2 model2);
+    }
+
+    [PublicAPI]
+    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, TEntity> : IAsyncEntityTranslator
+        where TEntity : IEntity
+    {
+        Task<TEntity> TranslateAsync(TModel1 model1, TModel2 model2, TModel3 model3);
+    }
+
+    [PublicAPI]
+    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, TEntity> : IAsyncEntityTranslator
+        where TEntity : IEntity
+    {
+        Task<TEntity> TranslateAsync(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4);
+    }
+
+    [PublicAPI]
+    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, TEntity> : IAsyncEntityTranslator
+        where TEntity : IEntity
+    {
+        Task<TEntity> TranslateAsync(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5);
+    }
+
+    [PublicAPI]
+    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, TEntity> : IAsyncEntityTranslator
+        where TEntity : IEntity
+    {
+        Task<TEntity> TranslateAsync(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6);
+    }
+
+    [PublicAPI]
+    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, TEntity> : IAsyncEntityTranslator
+        where TEntity : IEntity
+    {
+        Task<TEntity> TranslateAsync(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7);
+    }
+
+    [PublicAPI]
+    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, TEntity> : IAsyncEntityTranslator
+        where TEntity : IEntity
+    {
+        Task<TEntity> TranslateAsync(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7, TModel8 model8);
+    }
+
+    [PublicAPI]
+    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, in TModel9, TEntity> : IAsyncEntityTranslator
+        where TEntity : IEntity
+    {
+        Task<TEntity> TranslateAsync(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7, TModel8 model8, TModel9 model9);
+    }
+
+    [PublicAPI]
+    public interface IAsyncEntityTranslator<in TModel1, in TModel2, in TModel3, in TModel4, in TModel5, in TModel6, in TModel7, in TModel8, in TModel9, in TModel10, TEntity> : IAsyncEntityTranslator
+        where TEntity : IEntity
+    {
+        Task<TEntity> TranslateAsync(TModel1 model1, TModel2 model2, TModel3 model3, TModel4 model4, TModel5 model5, TModel6 model6, TModel7 model7, TModel8 model8, TModel9 model9, TModel10 model10);
     }
 
     [PublicAPI]


### PR DESCRIPTION
* 既存の `IAsync(Model|Entity)Translator` を `IObservable(Model|Entity)Translator` にリネーム
* 新たに `Task` を返す `IAsync(Model|Entity)Translator` を追加
* 破壊的な変更になりますが、利用者が少なかった機能なのでマイナーバージョンの更新とさせていただきます。