### PR TITLE
Remove dependency to @umm/cafu_generator

### DIFF
--- a/Assets/AssemblyDefinition.asmdef
+++ b/Assets/AssemblyDefinition.asmdef
@@ -1,7 +1,6 @@
 {
     "name": "umm@cafu_core",
     "references": [
-        "umm@cafu_generator",
         "umm@unirx",
         "umm@unirx_observablelifecyclemonobehaviour"
     ],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "scripts"
   ],
   "dependencies": {
-    "@umm/cafu_generator": "umm-projects/cafu_generator#^1.0.0",
     "@umm/scripts": "umm-projects/scripts#^1.0.0",
     "@umm/unirx": "umm-projects/unirx#^2.0.0",
     "@umm/unirx_observablelifecyclemonobehaviour": "umm-projects/unirx_observablelifecyclemonobehaviour#^1.0.0"


### PR DESCRIPTION
* CAFU Core did not dependent to `@umm/cafu_generator`
* `@umm/cafu_generator` should be added by project, if you need to use Generator.